### PR TITLE
Update dataset paths to new STA2 location

### DIFF
--- a/network/test.py
+++ b/network/test.py
@@ -85,9 +85,9 @@ def test(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--lmdb_train', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_train.lmdb')
-    parser.add_argument('--lmdb_valid', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_test.lmdb')
-    parser.add_argument('--lmdb_sn', default='/home/mcf/data/works/realcom/data/RealComShapeNetData/shapenet_data.lmdb')
+    parser.add_argument('--lmdb_train', default='/home/STA2/data/RealComData/realcom_data_train.lmdb')
+    parser.add_argument('--lmdb_valid', default='/home/STA2/data/RealComData/realcom_data_test.lmdb')
+    parser.add_argument('--lmdb_sn', default='/home/STA2/data/RealComShapeNetData/shapenet_data.lmdb')
     parser.add_argument('--class_name', default='all', choices=['all', 'chair', 'table', 'trash_bin', 'tv_or_monitor', 'cabinet', 'bookshelf', 'sofa', 'lamp', 'bed', 'tub'])
     parser.add_argument('--log_dir', default='weights/STA')
 

--- a/network/test_all_classifier.py
+++ b/network/test_all_classifier.py
@@ -76,9 +76,9 @@ def test(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--lmdb_train', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_train.lmdb')
-    parser.add_argument('--lmdb_valid', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_test.lmdb')
-    parser.add_argument('--lmdb_sn', default='/home/mcf/data/works/realcom/data/RealComShapeNetData/shapenet_data.lmdb')
+    parser.add_argument('--lmdb_train', default='/home/STA2/data/RealComData/realcom_data_train.lmdb')
+    parser.add_argument('--lmdb_valid', default='/home/STA2/data/RealComData/realcom_data_test.lmdb')
+    parser.add_argument('--lmdb_sn', default='/home/STA2/data/RealComShapeNetData/shapenet_data.lmdb')
     parser.add_argument('--class_name', default='all')
     parser.add_argument('--log_dir', default='weights/STA_classifier')
 

--- a/network/test_pcn.py
+++ b/network/test_pcn.py
@@ -85,9 +85,9 @@ def test(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--lmdb_train', default='/home/mcf/data/works/realcom/data/PCN/train')
-    parser.add_argument('--lmdb_valid', default='/home/mcf/data/works/realcom/data/PCN/test')
-    parser.add_argument('--lmdb_sn', default='/home/mcf/data/works/realcom/data/RealComShapeNetData/shapenet_data.lmdb')
+    parser.add_argument('--lmdb_train', default='/home/STA2/data/PCN/train')
+    parser.add_argument('--lmdb_valid', default='/home/STA2/data/PCN/test')
+    parser.add_argument('--lmdb_sn', default='/home/STA2/data/RealComShapeNetData/shapenet_data.lmdb')
     parser.add_argument('--class_name', default='chair', choices=['chair', 'table', 'cabinet', 'sofa', 'lamp'])
     parser.add_argument('--log_dir', default='weights/STA')
 

--- a/network/train.py
+++ b/network/train.py
@@ -41,9 +41,9 @@ def train(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     
-    parser.add_argument('--lmdb_train', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_train.lmdb')
-    parser.add_argument('--lmdb_valid', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_test.lmdb')
-    parser.add_argument('--lmdb_sn', default='/home/mcf/data/works/realcom/data/RealComShapeNetData/shapenet_data.lmdb')
+    parser.add_argument('--lmdb_train', default='/home/STA2/data/RealComData/realcom_data_train.lmdb')
+    parser.add_argument('--lmdb_valid', default='/home/STA2/data/RealComData/realcom_data_test.lmdb')
+    parser.add_argument('--lmdb_sn', default='/home/STA2/data/RealComShapeNetData/shapenet_data.lmdb')
 
     parser.add_argument('--class_name', default='all', choices=['all', 'chair', 'table', 'trash_bin', 'tv_or_monitor', 'cabinet', 'bookshelf', 'sofa', 'lamp', 'bed', 'tub'])
 

--- a/network/train_classifier.py
+++ b/network/train_classifier.py
@@ -41,9 +41,9 @@ def train(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     
-    parser.add_argument('--lmdb_train', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_train.lmdb')
-    parser.add_argument('--lmdb_valid', default='/home/mcf/data/works/realcom/data/RealComData/realcom_data_test.lmdb')
-    parser.add_argument('--lmdb_sn', default='/home/mcf/data/works/realcom/data/RealComShapeNetData/shapenet_data.lmdb')
+    parser.add_argument('--lmdb_train', default='/home/STA2/data/RealComData/realcom_data_train.lmdb')
+    parser.add_argument('--lmdb_valid', default='/home/STA2/data/RealComData/realcom_data_test.lmdb')
+    parser.add_argument('--lmdb_sn', default='/home/STA2/data/RealComShapeNetData/shapenet_data.lmdb')
 
     parser.add_argument('--class_name', default='all', choices=['all'])
 

--- a/network/train_pcn.py
+++ b/network/train_pcn.py
@@ -41,9 +41,9 @@ def train(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     
-    parser.add_argument('--lmdb_train', default='/home/mcf/data/works/realcom/data/PCN/train')
-    parser.add_argument('--lmdb_valid', default='/home/mcf/data/works/realcom/data/PCN/test')
-    parser.add_argument('--lmdb_sn', default='/home/mcf/data/works/realcom/data/RealComShapeNetData/shapenet_data.lmdb')
+    parser.add_argument('--lmdb_train', default='/home/STA2/data/PCN/train')
+    parser.add_argument('--lmdb_valid', default='/home/STA2/data/PCN/test')
+    parser.add_argument('--lmdb_sn', default='/home/STA2/data/RealComShapeNetData/shapenet_data.lmdb')
 
     parser.add_argument('--class_name', default='chair', choices=['chair', 'table', 'cabinet', 'sofa', 'lamp'])
 


### PR DESCRIPTION
## Summary
- replace hard-coded dataset roots pointing to `/home/mcf/data/works/realcom/data` with the simplified `/home/STA2/data`
- apply the new dataset root across all training and testing scripts so they reference the STA directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0c51ce4c083258744a20bf0ea17fc